### PR TITLE
Add handling of +1 prioritizing on MS rolls

### DIFF
--- a/RollFor/RollFor-BCC.toc
+++ b/RollFor/RollFor-BCC.toc
@@ -1,7 +1,7 @@
 ## Interface: 20502
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.7.12
+## Version: 4.8.0
 ## Notes: An automated item roller with soft ressing support via softres.it.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/RollFor.toc
+++ b/RollFor/RollFor.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: RollFor
 ## Author: Obszczymucha
-## Version: 4.7.12
+## Version: 4.8.0
 ## Notes: An automated item roller with soft ressing support via raidres.fly.dev.
 ## SavedVariables: RollForDb
 ## SavedVariablesPerCharacter: RollForCharDb

--- a/RollFor/src/AwardedLoot.lua
+++ b/RollFor/src/AwardedLoot.lua
@@ -8,7 +8,7 @@ local M = m.Module.new( "AwardedLoot" )
 local getn = m.getn
 
 ---@class AwardedLoot
----@field award fun( player_name: string, item_id: number, roll_data: RollData?, rolling_strategy: RollingStrategyType?, item_link: ItemLink?, player_class: PlayerClass?, sr_plus: number? )
+---@field award fun( player_name: string, item_id: number, roll_data: RollData?, rolling_strategy: RollingStrategyType?, item_link: ItemLink?, player_class: PlayerClass?, sr_plus: number?, plus_one: boolean )
 ---@field unaward fun( player_name: string, item_id: number )
 ---@field get_winners fun()
 ---@field update_item fun( index: number, data: table )
@@ -31,7 +31,8 @@ function M.new( db, group_roster, config )
   ---@param item_link ItemLink?
   ---@param player_class PlayerClass?
   ---@param sr_plus number?
-  local function award( player_name, item_id, roll_data, rolling_strategy, item_link, player_class, sr_plus )
+  ---@param plus_one boolean
+  local function award( player_name, item_id, roll_data, rolling_strategy, item_link, player_class, sr_plus, plus_one )
     M.debug.add( "award" )
     if not player_class then
       if roll_data and roll_data.player_class then
@@ -55,7 +56,8 @@ function M.new( db, group_roster, config )
       rolling_strategy = rolling_strategy,
       roll_type = roll_data and roll_data.roll_type,
       winning_roll = roll_data and roll_data.roll,
-      sr_plus = sr_plus
+      sr_plus = sr_plus,
+      plus_one = plus_one
     } )
   end
 

--- a/RollFor/src/Client.lua
+++ b/RollFor/src/Client.lua
@@ -38,6 +38,7 @@ function M.new( ace_timer, player_info, rolling_popup, config )
     pn = "player_name",
     pc = "player_class",
     rt = "roll_type",
+    pl = "plus_ones",
     r = "roll",
     n = "name",
     c = "class",
@@ -307,7 +308,7 @@ function M.new( ace_timer, player_info, rolling_popup, config )
           return
         end
 
-        roll_tracker.add( data.player_name, data.player_class, data.roll_type, data.roll )
+        roll_tracker.add( data.player_name, data.player_class, data.roll_type, data.roll, data.plus_ones or 0 )
         if data.player_name == player_info.get_name() then
           player_can_roll = false
         end

--- a/RollFor/src/ClientBroadcast.lua
+++ b/RollFor/src/ClientBroadcast.lua
@@ -151,13 +151,14 @@ function M.new( roll_controller, softres, config )
     } )
   end
 
-  ---@param data { player_name: PlayerName, player_class: PlayerClass, roll_type: RollType, roll: Roll }
+  ---@param data { player_name: PlayerName, player_class: PlayerClass, roll_type: RollType, roll: Roll, plus_ones: number }
   local function on_roll( data )
     broadcast( "ROLL", {
       pn = data.player_name,
       pc = data.player_class,
       rt = data.roll_type,
-      r = data.roll
+      r = data.roll,
+      pl = data.plus_ones
     } )
   end
 

--- a/RollFor/src/Config.lua
+++ b/RollFor/src/Config.lua
@@ -24,6 +24,8 @@ function M.new( db, event_bus )
   local callbacks = {}
   local toggles = {
     [ "auto_loot" ] = { cmd = "auto-loot", display = "Auto-loot", help = "toggle auto-loot" },
+    [ "handle_plus_ones"] = { cmd = "Handle-plus-ones", display = "handle-plus-ones", help = "Toggle +1 handling for main-spec rolls." },
+    [ "plus_one_prompt"] = { cmd = "plus-one-prompt", display = "Plus-one-prompt", help = "Prompt the user for whether the award should give a +1" },
     [ "superwow_auto_loot_coins" ] = { cmd = "superwow-auto-loot-coins", display = "Auto-loot coins with SuperWoW", help = "toggle auto-loot coins with SuperWoW" },
     [ "auto_loot_messages" ] = { cmd = "auto-loot-messages", display = "Auto-loot messages", help = "toggle auto-loot messages" },
     [ "auto_loot_announce" ] = { cmd = "auto-loot-announce", display = "Announce auto-looted items", help = "toggle announcements of auto-loot items" },
@@ -65,6 +67,8 @@ function M.new( db, event_bus )
     if db.master_loot_frame_rows == nil then db.master_loot_frame_rows = 5 end
     if db.auto_master_loot == nil then db.auto_master_loot = true end
     if db.auto_loot == nil then db.auto_loot = true end
+    if db.handle_plus_ones == nil then db.handle_plus_ones = false end
+    if db.plus_one_prompt == nil then db.plus_one_prompt = false end
     if db.auto_loot_announce == nil then db.auto_loot_announce = true end
     if db.loot_frame_cursor == nil then db.loot_frame_cursor = false end
     if db.client_show_roll_popup == nil then db.client_show_roll_popup = "Off" end

--- a/RollFor/src/MinimapButton.lua
+++ b/RollFor/src/MinimapButton.lua
@@ -104,10 +104,15 @@ function M.new( api, db, manage_softres_fn, winners_popup_fn, options_popup_fn, 
         api().GameTooltip:AddLine( string.format( "%s - %s", hl( "/rfr" ), white( "reset loot announce" ) ) )
         api().GameTooltip:AddLine( string.format( "%s - %s", hl( "/cr" ), white( "cancel rolling in progress" ) ) )
         api().GameTooltip:AddLine( string.format( "%s - %s", hl( "/fr" ), white( "finish rolling early" ) ) )
+        api().GameTooltip:AddLine( string.format( "%s - %s", hl( "/pl" ), white( "List +1's" ) ) )
+        api().GameTooltip:AddLine( string.format( "%s %s %s - %s", hl( "/pl add " ), grey( "<player>" ), grey( "<item>" ), white( "Add item to players +1's" ) ) )
+        api().GameTooltip:AddLine( string.format( "%s %s %s - %s", hl( "/pl rm" ), grey( "<player>" ), grey( "<item>" ), white( "Remove item from players +1's" ) ) )
         api().GameTooltip:AddLine( string.format( "%s - %s", hl( "/rf config" ), white( "show configuration" ) ) )
         api().GameTooltip:AddLine( string.format( "%s - %s", hl( "/rf config help" ), white( "show configuration help" ) ) )
         api().GameTooltip:AddLine( " " )
         api().GameTooltip:AddLine( "Click to manage softres." )
+        api().GameTooltip:AddLine( "Ctlr+Click for settings." )
+        api().GameTooltip:AddLine( "Shift+Click for winner overview." )
 
         if icon_color == ColorType.Green then
           api().GameTooltip:AddLine( " " )

--- a/RollFor/src/NonSoftResRollingLogic.lua
+++ b/RollFor/src/NonSoftResRollingLogic.lua
@@ -66,6 +66,9 @@ function M.new(
 
   local function sort_rolls()
     local f = function( a, b )
+      if a.roll_type == RollType.MainSpec and a.player.plus_ones ~= b.player.plus_ones then
+        return a.player.plus_ones < b.player.plus_ones
+      end
       if a.roll == b.roll then
         return a.player.name < b.player.name
       else
@@ -135,12 +138,14 @@ function M.new(
         local result = {}
         local last_roll
         local last_type
+        local last_plus_ones
 
         for _, roll in ipairs( all_rolls ) do
-          if not last_roll or last_roll ~= roll.roll or last_type ~= roll.roll_type then
+          if not last_roll or last_roll ~= roll.roll or last_type ~= roll.roll_type or roll.roll_type == RollType.MainSpec and last_plus_ones ~= roll.player.plus_ones  then
             table.insert( result, { roll } )
             last_roll = roll.roll
             last_type = roll.roll_type
+            last_plus_ones = roll.player.plus_ones
           else
             table.insert( result[ getn( result ) ], roll )
           end
@@ -186,7 +191,7 @@ function M.new(
     player.rolls = player.rolls - 1
     local t = ms_roll and mainspec_rolls or os_roll and offspec_rolls or tmog_rolls
     table.insert( t, make_roll( player, roll_type, roll ) )
-    controller.roll_was_accepted( player.name, player.class, roll_type, roll )
+    controller.roll_was_accepted( player.name, player.class, roll_type, roll, player.plus_ones )
 
     if have_all_rolls_been_exhausted() then find_winner() end
   end

--- a/RollFor/src/OptionsPopup.lua
+++ b/RollFor/src/OptionsPopup.lua
@@ -145,6 +145,7 @@ function M.new( popup_builder, awarded_loot, version_broadcast, event_bus, confi
       this.changelog.content.parent = this.changelog
 
       local changelog = {
+        { ver = "4.8.0", text = "Added +1 handling" },
         { ver = "4.7.12", text = "Fix trade bug outside raid. Fix minor bug in options window." },
         { ver = "4.7.11", text = "Fix bug in winners popup." },
         { ver = "4.7.10", text = "/src a[nnounce] command now supports /src aw for raid warning." },
@@ -310,6 +311,17 @@ function M.new( popup_builder, awarded_loot, version_broadcast, event_bus, confi
     e.create_gui_entry( "Rolling", frames, function()
       e.create_config( "Roll settings", nil, "header" )
       e.create_config( "Default rolling time", "default_rolling_time_seconds", "number|min=4|max=15", "Value must be between 4 and 15 seconds." )
+      this.handle_plus_ones = e.create_config( "Handle +1's on MS rolls", "handle_plus_ones", "checkbox", nil, function( value )
+        if value then
+          this:GetParent():GetParent().plus_one_prompt.input.enable()
+        else
+          this:GetParent():GetParent().plus_one_prompt.input.disable()
+        end
+      end )
+      this.plus_one_prompt = e.create_config("Always prompt for +1's", "plus_one_prompt", "checkbox" )
+      if not this.handle_plus_ones.input:GetChecked() then
+        this.plus_one_prompt.input.disable()
+      end
       e.create_config( "Rolling popup lock", "rolling_popup_lock", "checkbox", "Locks the rolling popup position.", notify )
       e.create_config( "Show Raid roll again button", "raid_roll_again", "checkbox", nil, notify )
       e.create_config( "MainSpec rolling threshold", "ms_roll_threshold", "number" )

--- a/RollFor/src/RollController.lua
+++ b/RollFor/src/RollController.lua
@@ -14,7 +14,7 @@ local hl = m.colors.hl
 
 ---@class RollControllerFacade
 ---@field roll_was_ignored fun( player_name: string, player_class: string?, roll_type: RollType, roll: number, reason: string )
----@field roll_was_accepted fun( player_name: string, player_class: string, roll_type: RollType, roll: number )
+---@field roll_was_accepted fun( player_name: string, player_class: string, roll_type: RollType, roll: number, plus_ones: number )
 ---@field tick fun( seconds_left: number )
 ---@field winners_found fun( item: Item, item_count: number, winners: Winner[], strategy: RollingStrategyType )
 ---@field finish fun()
@@ -857,10 +857,10 @@ function M.new(
     preview_sr_items_not_equal_to_item_count( soft_ressers, item, item_count, dropped_item, buttons, candidate_count, candidates )
   end
 
-  local function on_roll( player_name, player_class, roll_type, roll )
+  local function on_roll( player_name, player_class, roll_type, roll, plus_ones )
     M.debug.add( string.format( "on_roll( %s, %s, %s, %s )", player_name, player_class, roll_type, roll ) )
     local roll_tracker = get_roll_tracker( currently_displayed_item and currently_displayed_item.id )
-    roll_tracker.add( player_name, player_class, roll_type, roll )
+    roll_tracker.add( player_name, player_class, roll_type, roll, plus_ones )
 
     local data, current_iteration = roll_tracker.get()
     local strategy_type = current_iteration and current_iteration.rolling_strategy
@@ -870,7 +870,8 @@ function M.new(
         player_name = player_name,
         player_class = player_class,
         roll_type = roll_type,
-        roll = roll
+        plus_ones = plus_ones,
+        roll = roll,
       } )
     end
 

--- a/RollFor/src/RollingLogicUtils.lua
+++ b/RollFor/src/RollingLogicUtils.lua
@@ -21,7 +21,7 @@ end
 
 ---@param roller RollingPlayer
 function M.copy_roller( roller )
-  return make_rolling_player( roller.name, roller.class, roller.online, roller.rolls )
+  return make_rolling_player( roller.name, roller.class, roller.online, roller.rolls, roller.plus_ones )
 end
 
 ---@param rollers RollingPlayer[]

--- a/RollFor/src/RollingPopup.lua
+++ b/RollFor/src/RollingPopup.lua
@@ -6,6 +6,7 @@ if m.RollingPopup then return end
 local getn = m.getn
 local c = m.colorize_player_by_class
 local blue = m.colors.blue
+local RollType = m.Types.RollType
 
 local button_defaults = {
   width = 80,
@@ -180,7 +181,11 @@ function M.new( popup_builder, content_transformer, db, config )
         elseif type == "icon_text" then
           frame:SetText( v.value )
         elseif type == "roll" then
-          frame.roll_type:SetText( m.roll_type_color( v.roll_type, m.roll_type_abbrev( v.roll_type ) ) )
+          local roll_type_text = m.roll_type_abbrev( v.roll_type )
+          if v.roll_type == RollType.MainSpec and v.plus_ones > 0 then
+            roll_type_text = roll_type_text .. " +" .. v.plus_ones
+          end
+          frame.roll_type:SetText(m.roll_type_color( v.roll_type, roll_type_text))
           frame.player_name:SetText( c( v.player_name, v.player_class ) )
 
           if v.roll then

--- a/RollFor/src/RollingPopupContentTransformer.lua
+++ b/RollFor/src/RollingPopupContentTransformer.lua
@@ -105,10 +105,11 @@ function M.new( config )
       table.insert( result, {
         type = "roll",
         roll_type = roll.roll_type,
-        player_name = roll.player_name,
+        plus_ones = roll.plus_ones,
+        player_name =  roll.player_name,
         player_class = roll.player_class,
         roll = roll.roll,
-        padding = i == 1 and top_padding or nil
+        padding = i == 1 and top_padding or nil,
       } )
     end
   end

--- a/RollFor/src/RollingStrategyFactory.lua
+++ b/RollFor/src/RollingStrategyFactory.lua
@@ -4,6 +4,7 @@ local m = RollFor
 if m.RollingStrategyFactory then return end
 
 local M = {}
+local RollType = m.Types.RollType
 
 local getn = m.getn
 ---@type MakeRollingPlayerFn
@@ -43,7 +44,8 @@ function M.new(
     winner_tracker,
     config,
     softres,
-    player_info
+    player_info,
+    awarded_loot
 )
   ---@param item Item
   ---@param item_count number
@@ -54,7 +56,13 @@ function M.new(
   local function normal_roll( item, item_count, message, seconds, on_rolling_finished, roll_controller_facade )
     local players = group_roster.get_all_players_in_my_group()
     local rollers = m.map( players, function( player )
-      return make_rolling_player( player.name, player.class, player.online, 1 )
+      local plus_ones = 0
+      if config.handle_plus_ones() then
+        plus_ones = getn(m.filter(awarded_loot.get_winners(), (function (p) 
+          return p ~= nil and p.player_name == player.name and p.plus_one
+        end)))
+      end
+      return make_rolling_player( player.name, player.class, player.online, 1, plus_ones )
     end )
 
     return m.NonSoftResRollingLogic.new(
@@ -133,7 +141,7 @@ function M.new(
     local rollers = m.map( players,
       ---@param player RollingPlayer
       function( player )
-        return make_rolling_player( player.name, player.class, player.online, 1 )
+        return make_rolling_player( player.name, player.class, player.online, 1, player.plus_ones )
       end
     )
 

--- a/RollFor/src/SoftResRollingLogic.lua
+++ b/RollFor/src/SoftResRollingLogic.lua
@@ -210,7 +210,7 @@ function M.new(
 
     player.rolls = player.rolls - 1
     table.insert( rolls, make_roll( player, roll_type, roll ) )
-    controller.roll_was_accepted( player.name, player.class, roll_type, roll )
+    controller.roll_was_accepted( player.name, player.class, roll_type, roll, player.plus_ones )
 
     find_winner( State.AfterRoll )
   end

--- a/RollFor/src/TieRollingLogic.lua
+++ b/RollFor/src/TieRollingLogic.lua
@@ -143,7 +143,7 @@ function M.new( chat, players, item, item_count, on_rolling_finished, roll_type,
 
     player.rolls = player.rolls - 1
     table.insert( rolls, make_roll( player, roll_type, roll ) )
-    controller.roll_was_accepted( roller.name, player.class, roll_type, roll )
+    controller.roll_was_accepted( roller.name, player.class, roll_type, roll, player.plus_ones )
 
     if have_all_rolls_been_exhausted() then find_winner() end
   end

--- a/RollFor/src/Types.lua
+++ b/RollFor/src/Types.lua
@@ -183,13 +183,15 @@ end
 ---@field online boolean
 ---@field rolls number
 ---@field sr_plus number
+---@field plus_ones number
 ---@field type "RollingPlayer"
 
 ---@alias MakeRollingPlayerFn fun(
 ---  name: string,
 ---  class: PlayerClass,
 ---  online: boolean,
----  rolls: number ): RollingPlayer
+---  rolls: number,
+---  plus_ones: number ): RollingPlayer
 
 ---@type MakeRollingPlayerFn
 ---@param name string
@@ -197,13 +199,14 @@ end
 ---@param online boolean
 ---@param rolls number
 ---@return RollingPlayer
-function M.make_rolling_player( name, class, online, rolls )
+function M.make_rolling_player( name, class, online, rolls, plus_ones )
   return {
     name = name,
     class = class,
     online = online,
     rolls = rolls,
-    type = PlayerType.RollingPlayer
+    type = PlayerType.RollingPlayer,
+    plus_ones = plus_ones
   }
 end
 

--- a/test/InstaRaidRoll_test.lua
+++ b/test/InstaRaidRoll_test.lua
@@ -38,6 +38,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
         loot_frame_cursor = function() return false end,
       }
     end

--- a/test/IntegrationTestBuilder.lua
+++ b/test/IntegrationTestBuilder.lua
@@ -70,6 +70,7 @@ function M.mock_config( configuration )
     auto_class_announce = function() return true end,
     loot_frame_cursor = function() return false end,
     auto_tmog = function() return false end,
+    handle_plus_ones = function() return false end,
   }
 end
 
@@ -243,7 +244,7 @@ function M.new_roll_for()
       player_info
     )
 
-    local loot_award_callback = require( "src/LootAwardCallback" ).new( awarded_loot, roll_controller, winner_tracker, group_roster, softres )
+    local loot_award_callback = require( "src/LootAwardCallback" ).new( awarded_loot, roll_controller, winner_tracker, group_roster, softres, awarded_loot, config )
     local master_loot = require( "src/MasterLoot" ).new( ml_candidates, loot_award_callback, loot_list, roll_controller )
     deps[ "MasterLoot" ] = master_loot
 
@@ -256,7 +257,8 @@ function M.new_roll_for()
       winner_tracker,
       config,
       softres,
-      player_info
+      player_info,
+      awarded_loot
     )
     deps[ "RollingStrategyFactory" ] = strategy_factory
 

--- a/test/NormalRollSpec_test.lua
+++ b/test/NormalRollSpec_test.lua
@@ -306,7 +306,7 @@ function NoOneRollsSpec:should_display_finish_early_button_that_finishes_early()
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    offspec_roll( p2, 96, 11 ),
+    offspec_roll( p2, 96, 11, 0 ),
     text( "Rolling ends in 2 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -321,7 +321,7 @@ function NoOneRollsSpec:should_display_finish_early_button_that_finishes_early()
   chat.console( "RollFor: Rolling for [Bag] finished." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    offspec_roll( p2, 96, 11 ),
+    offspec_roll( p2, 96, 11, 0 ),
     text( "Obszczymucha wins the off-spec roll with 96.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -842,7 +842,7 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls()
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    offspec_roll( p2, 96, 11 ),
+    offspec_roll( p2, 96, 11, 0 ),
     text( "Rolling ends in 7 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -858,8 +858,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls()
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Rolling ends in 3 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -870,8 +870,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls()
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Rolling ends in 2 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -883,8 +883,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls()
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Rolling ends in 1 second.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -899,8 +899,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls()
   chat.console( "RollFor: Rolling for [Bag] finished." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Psikutas wins the main-spec roll with 69.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1006,7 +1006,7 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls_for_multiple_it
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 2 ),
-    offspec_roll( p2, 96, 11 ),
+    offspec_roll( p2, 96, 11, 0 ),
     text( "Rolling ends in 7 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1022,8 +1022,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls_for_multiple_it
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 2 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Rolling ends in 3 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1034,8 +1034,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls_for_multiple_it
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 2 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Rolling ends in 2 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1047,8 +1047,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls_for_multiple_it
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 2 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Rolling ends in 1 second.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1065,8 +1065,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls_for_multiple_it
   chat.console( "RollFor: Rolling for [Bag] finished." )
   rf.rolling_popup.should_display(
     item_link( item2, 2 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Psikutas wins the main-spec roll with 69.", 11 ),
     individual_award_button,
     text( "Obszczymucha wins the off-spec roll with 96.", 8 ),
@@ -1094,8 +1094,8 @@ function SomeoneRolledSpec:should_display_roll_button_that_rolls_for_multiple_it
   )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p1, 69, 11 ),
-    offspec_roll( p2, 96 ),
+    mainspec_roll( p1, 69, 11, 0 ),
+    offspec_roll( p2, 96, nil, 0 ),
     text( "Psikutas wins the main-spec roll with 69.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1188,7 +1188,7 @@ function SomeoneRolledSpec:should_display_close_button_that_closes_the_popup_and
   chat.console( "RollFor: Rolling for [Bag] finished." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    offspec_roll( p1, 69, 11 ),
+    offspec_roll( p1, 69, 11, 0 ),
     text( "Psikutas wins the off-spec roll with 69.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1223,7 +1223,7 @@ function SomeoneRolledSpec:should_display_close_button_that_closes_the_popup_and
   )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    offspec_roll( p1, 69, 11 ),
+    offspec_roll( p1, 69, 11, 0),
     text( "Psikutas wins the off-spec roll with 69.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1291,11 +1291,11 @@ function NormalTieRollSpec:should_display_tie_rolls()
   chat.raid( "Obszczymucha and Psikutas rolled the highest (69) for [Bag]." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    roll_placeholder( p2, "MainSpec", 11 ),
-    roll_placeholder( p1, "MainSpec" ),
+    roll_placeholder( p2, "MainSpec", 11, 0 ),
+    roll_placeholder( p1, "MainSpec", nil, 0 ),
     empty_line( 5 )
   )
 
@@ -1306,11 +1306,11 @@ function NormalTieRollSpec:should_display_tie_rolls()
   chat.raid( "Obszczymucha and Psikutas /roll for [Bag] now." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    roll_placeholder( p2, "MainSpec", 11 ),
-    roll_placeholder( p1, "MainSpec" ),
+    roll_placeholder( p2, "MainSpec", 11, 0 ),
+    roll_placeholder( p1, "MainSpec", nil, 0 ),
     text( "Waiting for remaining rolls...", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1324,14 +1324,14 @@ function NormalTieRollSpec:should_display_tie_rolls()
   chat.raid( "Obszczymucha and Psikutas re-rolled the highest (42) for [Bag]." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    mainspec_roll( p2, 42, 11 ),
-    mainspec_roll( p1, 42 ),
+    mainspec_roll( p2, 42, 11, 0 ),
+    mainspec_roll( p1, 42, nil, 0 ),
     text( "There was a tie (42):", 11 ),
-    roll_placeholder( p2, "MainSpec", 11 ),
-    roll_placeholder( p1, "MainSpec" ),
+    roll_placeholder( p2, "MainSpec", 11, 0 ),
+    roll_placeholder( p1, "MainSpec", nil, 0 ),
     empty_line( 5 )
   )
 
@@ -1342,14 +1342,14 @@ function NormalTieRollSpec:should_display_tie_rolls()
   chat.raid( "Obszczymucha and Psikutas /roll for [Bag] now." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    mainspec_roll( p2, 42, 11 ),
-    mainspec_roll( p1, 42 ),
+    mainspec_roll( p2, 42, 11, 0 ),
+    mainspec_roll( p1, 42, nil, 0 ),
     text( "There was a tie (42):", 11 ),
-    roll_placeholder( p2, "MainSpec", 11 ),
-    roll_placeholder( p1, "MainSpec" ),
+    roll_placeholder( p2, "MainSpec", 11, 0 ),
+    roll_placeholder( p1, "MainSpec", nil, 0 ),
     text( "Waiting for remaining rolls...", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1360,14 +1360,14 @@ function NormalTieRollSpec:should_display_tie_rolls()
   -- Then
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    mainspec_roll( p2, 42, 11 ),
-    mainspec_roll( p1, 42 ),
+    mainspec_roll( p2, 42, 11, 0 ),
+    mainspec_roll( p1, 42, nil, 0 ),
     text( "There was a tie (42):", 11 ),
-    mainspec_roll( p2, 1, 11 ),
-    roll_placeholder( p1, "MainSpec" ),
+    mainspec_roll( p2, 1, 11, 0 ),
+    roll_placeholder( p1, "MainSpec", nil, 0 ),
     text( "Waiting for remaining rolls...", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1380,14 +1380,14 @@ function NormalTieRollSpec:should_display_tie_rolls()
   chat.console( "RollFor: Rolling for [Bag] finished." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    mainspec_roll( p2, 42, 11 ),
-    mainspec_roll( p1, 42 ),
+    mainspec_roll( p2, 42, 11, 0 ),
+    mainspec_roll( p1, 42, nil, 0 ),
     text( "There was a tie (42):", 11 ),
-    mainspec_roll( p1, 2, 11 ),
-    mainspec_roll( p2, 1 ),
+    mainspec_roll( p1, 2, 11, 0 ),
+    mainspec_roll( p2, 1, nil, 0 ),
     text( "Psikutas wins the main-spec roll with 2.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1407,14 +1407,14 @@ function NormalTieRollSpec:should_display_tie_rolls()
   rf.confirmation_popup.should_be_hidden()
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p2, 69, 11 ),
-    mainspec_roll( p1, 69 ),
+    mainspec_roll( p2, 69, 11, 0 ),
+    mainspec_roll( p1, 69, nil, 0 ),
     text( "There was a tie (69):", 11 ),
-    mainspec_roll( p2, 42, 11 ),
-    mainspec_roll( p1, 42 ),
+    mainspec_roll( p2, 42, 11, 0 ),
+    mainspec_roll( p1, 42, nil, 0 ),
     text( "There was a tie (42):", 11 ),
-    mainspec_roll( p1, 2, 11 ),
-    mainspec_roll( p2, 1 ),
+    mainspec_roll( p1, 2, 11, 0 ),
+    mainspec_roll( p2, 1, nil, 0 ),
     text( "Psikutas wins the main-spec roll with 2.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1507,8 +1507,8 @@ function NormalTieRollSpec:should_not_consider_ms_and_tm_rolls_tie()
   chat.console( "RollFor: Rolling for [Bag] finished." )
   rf.rolling_popup.should_display(
     item_link( item2, 1 ),
-    mainspec_roll( p1, 42, 11 ),
-    offspec_roll( p2, 42 ),
+    mainspec_roll( p1, 42, 11, 0 ),
+    offspec_roll( p2, 42, nil, 0 ),
     text( "Psikutas wins the main-spec roll with 42.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )
@@ -1599,7 +1599,7 @@ function NoOneRollsSpec:should_show_award_button_when_looting_the_corpse_again_i
   chat.raid( "Stopping rolls in 3" )
   rf.rolling_popup.should_display(
     item_link( item, 1 ),
-    mainspec_roll( p1, 24, 11 ),
+    mainspec_roll( p1, 24, 11, 0 ),
     text( "Rolling ends in 2 seconds.", 11 ),
     buttons( "FinishEarly", "Cancel" )
   )
@@ -1615,7 +1615,7 @@ function NoOneRollsSpec:should_show_award_button_when_looting_the_corpse_again_i
   chat.console( "RollFor: Rolling for [Essence Gatherer] finished." )
   rf.rolling_popup.should_display(
     item_link( item, 1 ),
-    mainspec_roll( p1, 24, 11 ),
+    mainspec_roll( p1, 24, 11, 0 ),
     text( "Cosmicshadow wins the main-spec roll with 24.", 11 ),
     buttons( "RaidRoll", "Close" )
   )
@@ -1629,7 +1629,7 @@ function NoOneRollsSpec:should_show_award_button_when_looting_the_corpse_again_i
   )
   rf.rolling_popup.should_display(
     item_link( item, 1 ),
-    mainspec_roll( p1, 24, 11 ),
+    mainspec_roll( p1, 24, 11, 0 ),
     text( "Cosmicshadow wins the main-spec roll with 24.", 11 ),
     buttons( "AwardWinner", "RaidRoll", "AwardOther", "Close" )
   )

--- a/test/RaidRoll_test.lua
+++ b/test/RaidRoll_test.lua
@@ -38,6 +38,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
         loot_frame_cursor = function() return false end,
       }
     end

--- a/test/both_spec_rolls_test.lua
+++ b/test/both_spec_rolls_test.lua
@@ -37,6 +37,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
       }
     end
   }

--- a/test/generic_test.lua
+++ b/test/generic_test.lua
@@ -39,6 +39,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
       }
     end
   }

--- a/test/gui_helpers.lua
+++ b/test/gui_helpers.lua
@@ -16,8 +16,8 @@ end
 ---@param player Player
 ---@param roll_type RollType
 ---@param padding number?
-function M.roll_placeholder( player, roll_type, padding )
-  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = roll_type, padding = padding }
+function M.roll_placeholder( player, roll_type, padding, plus_ones )
+  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = roll_type, padding = padding, plus_ones = plus_ones }
 end
 
 ---@param player Player
@@ -28,26 +28,26 @@ end
 
 ---@param player Player
 ---@param padding number?
-function M.mainspec_roll( player, roll, padding )
-  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.MainSpec, roll = roll, padding = padding }
+function M.mainspec_roll( player, roll, padding, plus_ones )
+  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.MainSpec, roll = roll, padding = padding, plus_ones = plus_ones }
 end
 
 ---@param player Player
 ---@param padding number?
-function M.offspec_roll( player, roll, padding )
-  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.OffSpec, roll = roll, padding = padding }
+function M.offspec_roll( player, roll, padding, plus_ones )
+  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.OffSpec, roll = roll, padding = padding, plus_ones = plus_ones }
 end
 
 ---@param player Player
 ---@param padding number?
-function M.tmog_roll( player, roll, padding )
-  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.Transmog, roll = roll, padding = padding }
+function M.tmog_roll( player, roll, padding, plus_ones )
+  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.Transmog, roll = roll, padding = padding, plus_ones = plus_ones }
 end
 
 ---@param player Player
 ---@param padding number?
-function M.softres_roll( player, roll, padding )
-  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.SoftRes, roll = roll, padding = padding }
+function M.softres_roll( player, roll, padding, plus_ones )
+  return { type = "roll", player_name = player.name, player_class = player.class, roll_type = RT.SoftRes, roll = roll, padding = padding, plus_ones = plus_ones }
 end
 
 ---@param message string

--- a/test/mainspec_rolls_test.lua
+++ b/test/mainspec_rolls_test.lua
@@ -42,6 +42,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
         loot_frame_cursor = function() return false end,
       }
     end

--- a/test/offspec_rolls_test.lua
+++ b/test/offspec_rolls_test.lua
@@ -37,6 +37,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
         loot_frame_cursor = function() return false end,
       }
     end

--- a/test/softres_rolls_test.lua
+++ b/test/softres_rolls_test.lua
@@ -57,6 +57,7 @@ local mock_config = function( config )
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
         loot_frame_cursor = function() return false end,
       }
     end

--- a/test/tie_rolls_test.lua
+++ b/test/tie_rolls_test.lua
@@ -38,6 +38,7 @@ local function mock_config()
         award_filter = function() return {} end,
         keep_award_data = function() return false end,
         auto_tmog = function() return false end,
+        handle_plus_ones = function() return false end,
       }
     end
   }


### PR DESCRIPTION
Hello!

In my guild we have this system where if you win a main spec roll, you get a +1. If you're rolling against someone with a +1 and you don't have a +1 yourself, you win the roll no matter what. If you won 2 main spec rolls, you now have +2 and even +1's will win against your roll no matter what. All the people with the lowest amount of + will roll against each other.

Here are a few examples.
```
Bob MS +1 rolled 99
Alice MS +2 rolled 99
Peter MS +0 rolled 1
Peter wins the roll and is now MS +1
```
```
Bob OS rolled 88
Peter MS +3 rolled 10
Peter wins the roll and is now MS +4
```
```
Bob OS rolled 66
Peter OS rolled 55
Bob wins the roll and no MS + is added
```



My guild is doing this by having a spreadsheet on the side, and then manually calculating who should be in the roll, and manually finding the winner out of those.

This pull request should hopefully be able to replace that spreadsheet, and remove the need of tapping in and out of the game as a master looter.

I've also added the command `/pl` for listing who has MS+ and which items they won to get the +
Also `/pl add <player> <item>` and `/pl rm <player> <item>` for manually adjusting the +1 of players.

![Capture](https://github.com/user-attachments/assets/68c83193-0a4e-4f28-a9c0-2e09f267fac1)
![pl](https://github.com/user-attachments/assets/4d63cf34-abb0-45d2-8ffb-9e50cab15c8c)
